### PR TITLE
Fix gimme tag exclusions

### DIFF
--- a/tle/cogs/codeforces.py
+++ b/tle/cogs/codeforces.py
@@ -114,8 +114,8 @@ class Codeforces(commands.Cog):
         for arg in args:
             if arg.isdigit():
                 rating = int(arg)
-            elif arg.startswith("-"):
-                exclusions.append(arg)
+            elif arg.startswith('-'):
+                exclusions.append(arg[1:])
             else:
                 tags.append(arg)
 
@@ -128,7 +128,7 @@ class Codeforces(commands.Cog):
         
         if tags:
             problems = [prob for prob in problems if prob.tag_matches(tags)]
-            problems = [prob for prob in problems if not any(exclude in prob.tags for exclude in exclusions)]
+            problems = [prob for prob in problems if not any(any(exclude in tag for tag in prob.tags) for exclude in exclusions)]
 
         if not problems:
             raise CodeforcesCogError('Problems not found within the search parameters')


### PR DESCRIPTION
Fix bug introduced in #2 where `-tag` would be the exclusion rather than `tag`. Now allows for partial matching meaning exclusions will get matched if they're a substring of the tag.