### PR TITLE
Use CF Rating API for user.ratedList

### DIFF
--- a/tle/util/codeforces_api.py
+++ b/tle/util/codeforces_api.py
@@ -10,6 +10,7 @@ import aiohttp
 from discord.ext import commands
 
 API_BASE_URL = 'https://codeforces.com/api/'
+RATING_BASE_URL = 'https://cf-rating-api.vercel.app/api/'
 CONTEST_BASE_URL = 'https://codeforces.com/contest/'
 CONTESTS_BASE_URL = 'https://codeforces.com/contests/'
 GYM_BASE_URL = 'https://codeforces.com/gym/'
@@ -243,6 +244,8 @@ def cf_ratelimit(f):
 @cf_ratelimit
 async def _query_api(path, params=None):
     url = API_BASE_URL + path
+    if 'user.ratedList' in path:
+        url = RATING_BASE_URL + path
     try:
         logger.info(f'Querying CF API at {url} with {params}')
         # Explicitly state encoding (though aiohttp accepts gzip by default)


### PR DESCRIPTION
Use https://cf-rating-api.vercel.app/api/user.ratedList for user.ratedList queries instead of CF API. The API queries CF API and removes all information other than `handle` and `rating`, which seems to work fine with TLE. This should resolve the current MLE issue.